### PR TITLE
docs: Add Groq API and Kimi2 model documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ npm install
 ```bash
 # Copy from .env.local.example or add your API keys
 OPENAI_API_KEY=your_openai_api_key
+GROQ_API_KEY=your_groq_api_key
 FIRECRAWL_API_KEY=your_firecrawl_api_key
 ```
 
@@ -31,3 +32,13 @@ Open [http://localhost:3000](http://localhost:3000) to view the application.
 - Real-time scoring and recommendations
 - Visual charts and metrics
 - SEO and accessibility checks
+
+## AI Models
+
+This application uses multiple AI providers for analysis:
+
+- **Groq API**: Primary AI provider using the `moonshotai/kimi-k2-instruct` model for website analysis
+- **OpenAI API**: Fallback option when Groq is unavailable
+- **Kimi2 Model**: Advanced language model accessed through Groq API for AI readiness insights
+
+The system automatically prioritizes Groq API due to OpenAI quota limitations and falls back to mock data if both services are unavailable.


### PR DESCRIPTION
## Summary
- Document the actual AI models used in the codebase
- Add GROQ_API_KEY to environment variables setup
- Explain the AI provider fallback mechanism

## Changes
- Added `GROQ_API_KEY` to the environment variables section
- Created new "AI Models" section documenting:
  - Groq API as primary provider using `moonshotai/kimi-k2-instruct` model
  - OpenAI API as fallback option
  - Automatic fallback to mock data when both APIs are unavailable

## Test plan
- [x] Verify README accurately reflects the codebase implementation
- [x] Confirm all required environment variables are documented
- [x] Check that the AI provider priority is correctly described

🤖 Generated with [Claude Code](https://claude.ai/code)